### PR TITLE
Resolvendo listas duplicadas quando você se desinscreve de uma lista

### DIFF
--- a/resources/views/subscriptions/listas.blade.php
+++ b/resources/views/subscriptions/listas.blade.php
@@ -11,8 +11,8 @@
 <p>
 Selecione a lista para solicitar sua desinscrição. Para se inscrever novamente, remova seu check (não precisa apagar o motivo da desinscrição).  
 <br>
-<input  type="checkbox" value="" name="">: Listas inscritas &nbsp;&nbsp;  
-<input  type="checkbox" value="" name="" checked> Listas desinscritas. 
+<input  type="checkbox" value="" name="" disabled>: Listas inscritas &nbsp;&nbsp;  
+<input  type="checkbox" value="" name="" checked disabled> Listas desinscritas. 
 </p>
 
 @if(sizeof($listas) > 0 || sizeof($unsubscribed_listas) > 0)


### PR DESCRIPTION
Quando você se desinscrevia de alguma lista e voltava para a página de gerenciamento de inscrições a lista aparecia duplicada, uma checkada e outra não.
O erro acontecia porque ao se desinscrever da lista, os emails dela não são atualizados, então só fica marcado na tabela unsubscribe a relação email-lista. Agora a desinscrição só ocorre, de fato, quando os emails da lista são atualizados, ação realizada pelo administrador da lista. 

O que estava causando o erro era o comentário nas linhas 92 e 114 do SubscriptionController, ao se desinscrever da lista, ela não atualiza mais os emails pois o processo pode demorar muito, devido a algumas listas serem muito grandes.

//Mailman::emails(Lista::where('id', $remove['id_lista'])->get()->first());//atualiza os emails da lista --> TEM QUE MELHORAR A PERFORMANCE